### PR TITLE
Update spec.md

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -29,7 +29,7 @@
 
   | method |       path        |  Request   |       Response       |
   | :----: | :---------------: | :--------: | :------------------: |
-  | `GET`  | /api/v1/topsearch | (json) 검색어 | (json) 상단 해시태그 검색 결과 |
+  | `POST` | /api/v1/topsearch | (json) 검색어 | (json) 상단 해시태그 검색 결과 |
 
   <br>
 
@@ -90,7 +90,7 @@
 
   | method |     path      |          Request          |    Response     |
   | :----: | :-----------: | :-----------------------: | :-------------: |
-  | `GET`  | /api/v1/crawl | (json) 동의어를 포함한 메타 검색어 정보 | (json) 메타 검색 결과 |
+  | `POST` | /api/v1/crawl | (json) 동의어를 포함한 메타 검색어 정보 | (json) 메타 검색 결과 |
 
   <br>
 


### PR DESCRIPTION
GET
HTTP/1.1 스펙인 RFC2616의 Section9.3에 따르면 GET은 서버로부터 정보를 조회하기 위해 설계된 메소드입니다.
GET은 요청을 전송할 때 필요한 데이터를 Body에 담지 않고, 쿼리스트링을 통해 전송합니다. URL의 끝에 ?와 함께 이름과 값으로 쌍을 이루는 요청 파라미터를 쿼리스트링이라고 부릅니다.

POST
POST는 리소스를 생성/변경하기 위해 설계되었기 때문에 GET과 달리 전송해야될 데이터를 HTTP 메세지의 Body에 담아서 전송합니다.


[ POST방식의 특징 ]
URL에 변수(데이터)를 노출하지 않고 요청한다.

데이터를 Body(바디)에 포함시킨다.

URL에 데이터가 노출되지 않아서 기본 보안은 되어있다.

전송하는 길이에 제한이 없다.

캐싱할 수 없다.

라는 것에 기반해 post라고 생각합니다,,